### PR TITLE
HttpURLConnection mem leak and unclosed file descriptors fix

### DIFF
--- a/src/main/java/com/trendrr/nsq/lookup/NSQLookupDynMapImpl.java
+++ b/src/main/java/com/trendrr/nsq/lookup/NSQLookupDynMapImpl.java
@@ -80,16 +80,17 @@ public class NSQLookupDynMapImpl implements NSQLookup {
 	    	  log.error("Caught", e);
 	      } finally {
 	    	  try {
-	    		  if (rd != null)
-	    			  rd.close();
-					} catch (Exception e) {
-						log.error("Caught", e);
-					}
+    			  if (rd != null){
+    		  	  	rd.close();
+    		  	  }	    			
+				} catch (Exception e) {
+					log.error("Caught", e);
+				}
 
-					// Release memory and underlying resources on the HttpURLConnection otherwise we may run out of file descriptors and leak memory
-					if (conn != null){
-						conn.disconnect();
-					}
+				// Release memory and underlying resources on the HttpURLConnection otherwise we may run out of file descriptors and leak memory
+				if (conn != null){
+					conn.disconnect();
+				}
 	      }
 	      return result;
 	   } 


### PR DESCRIPTION
The HttpURLConnection object is leaking memory and not properly closing file descriptors whenever we look up hosts for a given topic.

This is exacerbated by the fact that if the no hosts can be found for a given topic, the NSQLookupDynMapImpl will keep trying to find the publishing hosts at regular intervals, thereby instantiating new HttpURLConnection objects which never release file descriptors and memory. We need release resources by calling disconnect().

This fix address the major issue discussed above.

Cheers,
Ed.
