### PR TITLE
Update to Netty 3.6.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
-      <version>3.6.1.Final</version>
+      <version>3.6.10.Final</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
When shutting down a heavily-loaded consumers with Netty 3.6.1.Final,
I was seeing deadlock of the form:

"Thread-12":
      at org.jboss.netty.channel.socket.nio.AbstractNioWorker.cleanUpWriteBuffer(AbstractNioWorker.java:374)
      - waiting to lock <0x0000000782205550> (a java.lang.Object)
      at org.jboss.netty.channel.socket.nio.AbstractNioWorker.close(AbstractNioWorker.java:349)
      at org.jboss.netty.channel.socket.nio.NioClientSocketPipelineSink.eventSunk(NioClientSocketPipelineSink.java:57)
      at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendDownstream(DefaultChannelPipeline.java:775)
      at org.jboss.netty.handler.codec.oneone.OneToOneEncoder.handleDownstream(OneToOneEncoder.java:54)
      at org.jboss.netty.channel.DefaultChannelPipeline.sendDownstream(DefaultChannelPipeline.java:587)
      at org.jboss.netty.channel.DefaultChannelPipeline.sendDownstream(DefaultChannelPipeline.java:578)
      at org.jboss.netty.channel.Channels.close(Channels.java:812)
      at org.jboss.netty.channel.AbstractChannel.close(AbstractChannel.java:197)
      at com.trendrr.nsq.Connection.close(Connection.java:185)
      at com.trendrr.nsq.Connections.close(Connections.java:121)
      - locked <0x0000000781ddd220> (a com.trendrr.nsq.Connections)
      at com.trendrr.nsq.AbstractNSQClient.close(AbstractNSQClient.java:219)
      ....

"New I/O worker #38":
      at com.trendrr.nsq.Connections.remove(Connections.java:95)
      - waiting to lock <0x0000000781ddd220> (a com.trendrr.nsq.Connections)
      at com.trendrr.nsq.AbstractNSQClient._disconnected(AbstractNSQClient.java:214)
      - locked <0x0000000781ddd1e8> (a com.trendrr.nsq.NSQConsumer)
      at com.trendrr.nsq.Connection._disconnected(Connection.java:151)
      at com.trendrr.nsq.netty.NSQHandler.exceptionCaught(NSQHandler.java:64)
      at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:112)
      at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:560)
      at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:787)
      at org.jboss.netty.handler.codec.frame.FrameDecoder.exceptionCaught(FrameDecoder.java:377)
      at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:112)
      at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:560)
      at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:555)
      at org.jboss.netty.channel.Channels.fireExceptionCaught(Channels.java:525)
      at org.jboss.netty.channel.socket.nio.AbstractNioWorker.write0(AbstractNioWorker.java:248)
      - locked <0x0000000782205550> (a java.lang.Object)
      at org.jboss.netty.channel.socket.nio.AbstractNioWorker.writeFromTaskLoop(AbstractNioWorker.java:150)
      at org.jboss.netty.channel.socket.nio.AbstractNioChannel$WriteTask.run(AbstractNioChannel.java:335)
      at org.jboss.netty.channel.socket.nio.AbstractNioSelector.processTaskQueue(AbstractNioSelector.java:367)
      at org.jboss.netty.channel.socket.nio.AbstractNioSelector.run(AbstractNioSelector.java:291)
      at org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioWorker.java:88)
      at org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:178)
      at org.jboss.netty.util.ThreadRenamingRunnable.run(ThreadRenamingRunnable.java:108)
      at org.jboss.netty.util.internal.DeadLockProofWorker$1.run(DeadLockProofWorker.java:42)
      at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
      at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
      at java.lang.Thread.run(Thread.java:745)

Upgrading to Netty 3.6.10.Final has resolved the issue in my testing.