### PR TITLE
Don't call _disconnected() in Connection.close()

### DIFF
--- a/src/main/java/com/trendrr/nsq/Connection.java
+++ b/src/main/java/com/trendrr/nsq/Connection.java
@@ -187,7 +187,6 @@ public class Connection {
 			log.error("Caught", x);
 		}
 		log.warn("Close called on connection: " + this);
-		this._disconnected();
 	}
 
 	/**


### PR DESCRIPTION
This change prevents a deadlock that was observed when closing NSQProducer (see issue #13). This is was originally opened as pull request #14, but a couple of other changes got mixed in with that one, so I'm re-issuing it as a distinct pull request.

The `_disconnected()` method will be invoked later by `NSQHandler.channelDisconnected()`, so there is no need to also call it in Connection.close().

In the case of an exception on the connection, _disconnected() will be invoked by `NSQHandler.exceptionCaught()`.